### PR TITLE
fix: Update Travis config to fix npm deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 language: node_js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ script:
 
 deploy:
   provider: script
+  skip_cleanup: true
   script: bash bin/travis-deploy.sh
   on:
     tags: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpns-contract",
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpns-contract",
-  "version": "0.2.0-dev.2",
+  "version": "0.2.0-dev.3",
   "description": "A contract and helper scripts for DPNS DApp",
   "scripts": {
     "register": "node scripts/register",


### PR DESCRIPTION
This removes sudo requirement (unrelated but probably good cleanup if unused) and also tells Travis to skip cleanup upon deploy, which will allow the npm token to work to push the package.