### PR TITLE
chore: Bump latest Node LTS version

### DIFF
--- a/bin/travis-deploy.sh
+++ b/bin/travis-deploy.sh
@@ -4,7 +4,7 @@ set -xe
 
 # Update this whenever the latest Node.js LTS version changes (~ every year).
 # Do not forget to add this version to .travis.yml config also.
-LATEST_LTS_VERSION="10"
+LATEST_LTS_VERSION="12"
 
 # We want this command to succeed whether or not the Node.js version is the
 # latest (so that the build does not show as failed), but _only_ the latest


### PR DESCRIPTION
This will start deploying using Node v12 instead of v10.

@jawid-h Happy to discuss if we'd rather deploying using lowest active LTS version but for now this is how the script is written. Let me know if you want to discuss first instead.