### PR TITLE
feat: allowSubdomains can have `true` value

### DIFF
--- a/schema/dpns-contract-documents.json
+++ b/schema/dpns-contract-documents.json
@@ -34,7 +34,7 @@
         "pattern": "^((?!-)[a-z0-9-]{0,62}[a-z0-9])$",
         "maxLength": 63,
         "description": "Domain label in a lower case for case insensitive uniqueness validation. e.g. 'bob'",
-        "$comment": "This property will be deprecated due to case insensitive indices. Must be equal to label in lowercase."
+        "$comment": "This property will be deprecated due to case insensitive indices. Must be equal to label in lowercase"
       },
       "normalizedParentDomainName": {
         "type": "string",
@@ -42,7 +42,7 @@
         "minLength": 0,
         "maxLength": 190,
         "description": "A full parent domain name in lower case for case insensitive uniqueness validation. e.g. 'dash'",
-        "$comment": "Must be equal to existing domain or can be empty if you want to create a top level domain. Only the contract owner can create top level domains."
+        "$comment": "Must be equal to existing domain or can be empty if you want to create a top level domain. Only the contract owner can create top level domains"
       },
       "preorderSalt": {
         "type": "string",
@@ -82,8 +82,7 @@
         "properties": {
           "allowSubdomains": {
             "type": "boolean",
-            "const": false,
-            "description": "This option defines who can create subdomains. Only domain owner is allowed at the moment"
+            "description": "This option defines who can create subdomains"
           }
         },
         "description": "Subdomain rules allows to define rules for subdomains",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
allowSubdomains can have `true` value to allow subdomains registration for the third party identities

## What was done?
<!--- Describe your changes in detail -->
Changed DPNS contract

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
